### PR TITLE
provide ext-gettext

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "provide":  {
+        "ext-gettext":"self.version"
+    },
     "autoload": {
         "psr-0": {
             "smmoosavi": "src/"


### PR DESCRIPTION
this way this package could solve dependecy issues of packages having "require":"ext-gettext"

altho for this fully to work, would need to register functions in global namespace as well
